### PR TITLE
Changed search string on subheadings to lowercase

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -152,7 +152,7 @@
                 });
                 //search function
                 $("div.tab-pane input.search").keyup(function () {
-                    var search = $(this).val();
+                    var search = $(this).val().toLowerCase();
                     $(this).parent().parent().find("tr").hide();
                     $(this).parent().parent().find("tbody tr").each(function () {
                         if ($(this).text().toLowerCase().indexOf(search) != -1) {


### PR DESCRIPTION
Should be set. The subheadings have a different search because they present the results in a much different way than the global search. It could probably be cleaned up though. 