### PR TITLE
Small css fix

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -52,7 +52,7 @@
         <meta name="theme-color"                        content="#ffffff">
         <!-- Latest compiled and minified CSS -->
         <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
-        <link rel="stylesheet" href="/css/styles.css">
+        <link rel="stylesheet" href="css/styles.css">
         <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
         <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
         <!--[if lt IE 9]>


### PR DESCRIPTION
Use "css/styles.css" instead of "/css/styles.css".

If you use trumptracker.github.io/css/styles.css, it works, but if you use a subdirectory like mrluit.github.io/trumptracker/ it tries to find mrluit.github.io/css/styles.css while it needs to find mrluit.github.io/trumptracker/css/styles.css. 

This fixes that :)