### PR TITLE
input type="search" for search input

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,7 +104,7 @@ comments: false
                   <div class="row">
                   <div class="input-group">
                     <div class="input-group-addon"><span>Search </span></div>
-                    <input type="text" placeholder="keyword" class="form-control search"/>
+                    <input type="search" placeholder="keyword" class="form-control search"/>
                   </div>
                     {% for section in tab.sections %}
                       <table class="table table-striped">


### PR DESCRIPTION
More semantically correct and better for accessibility.