### PR TITLE
Update Rake task to use HTML-Proofer directly

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -61,7 +61,7 @@ task :test do
     :cache => { :timeframe => '15d' },
     :enforce_https => true,
     :check_external_hash => true,
-    :url_ignore => [/https:\/\/web.archive.org\/web\/*\//]
+    :url_ignore => [/https:\/\/web.archive.org\/web\//]
   }
   HTMLProofer.check_directory("./_site", options).run
 end

--- a/Rakefile
+++ b/Rakefile
@@ -47,8 +47,21 @@ end
 
 
 task :test do
+  require 'html-proofer'
   sh "rm -rf ./_site"
   sh "bundle exec jekyll build"
-  Rake::Task["json2yaml"].invoke  
-  sh "bundle exec htmlproofer --allow-hash-href --check-favicon --check-opengraph --check-html --check-img-http --timeframe 15d --enforce-https --check-external-hash --url-ignore https://web.archive.org/web/* ./_site"
+  Rake::Task["json2yaml"].invoke
+
+  options = {
+    :allow_hash_href => true,
+    :check_favicon => true,
+    :check_opengraph => true,
+    :check_html => true,
+    :check_img_http => true,
+    :cache => { :timeframe => '15d' },
+    :enforce_https => true,
+    :check_external_hash => true,
+    :url_ignore => [/https:\/\/web.archive.org\/web\/*\//]
+  }
+  HTMLProofer.check_directory("./_site", options).run
 end


### PR DESCRIPTION
Hello! This PR is in response to https://github.com/gjtorikian/html-proofer/issues/418.

I made a couple of changes to the way the test suite was run. First, I opted to just use the Ruby method of `HTMLProofer.check_directory` directly, rather than shell out to the command line. I find it easier to read the `options` that are passed in directly this way.

Second, I believe that `--url-ignore https://web.archive.org/web/*` was not working because it was mixing [POSIX wildcards](http://tldp.org/LDP/GNU-Linux-Tools-Summary/html/x11655.htm) with [the regular expression asterisk](http://rubyforadmins.com/regular-expressions). In a regular expression, `/*` means "~~one~~ zero or more  `/`s", which is not what you intended. 

In any event, you also don't need to whitelist all the paths, either. Simply saying `:url_ignore => [/https:\/\/web.archive.org\/web\//]` ensures that any `https://web.archive.org/web/` link is ignored. Similarly, this can be extended to match any domain: `[/https:\/\/(web.archive.org\/web\/web.archive|redd.it|youtu.be|youtube)/]`. You don't need to define matching identifiers for every possible URL path.

Hope this helps! Keep resisting. ✊ 