### PR TITLE
Change 'Loading...' to '...'

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@ layout: page
                 </li> -->
                 <li class="list-group-item list-group-item">
                     <i class="fa fa-calendar fa-fw"></i>
-                    <b>Days In Office: <span id="days-in-office"><i class='loading'>Loading...</i></span></b>
+                    <b>Days In Office: <span id="days-in-office"><i class='loading'>...</i></span></b>
                 </li>
 
                 {% for status in statuses %}


### PR DESCRIPTION
### Description of your *pull request*, and other information
---
Right now, especially on a slow connection, `Loading...` appears before the actual days in office. `...` instead matches better to the number of days and looks cleaner.
---

### Make sure you are using the *latest* version: pull latest commits before reporting any issues.
- [x] I've **verified** and **I assure** that I'm looking at the latest version of Trump Tracker.

### Before submitting a *Pull Request* make sure you have:
- [x] At least skimmed through [README](https://github.com/TrumpTracker/trumptracker.github.io/blob/master/README.md) and **most notably** the [To Do List](https://github.com/TrumpTracker/trumptracker.github.io#to-do-list) and [CONTRIBUTING.md](https://github.com/TrumpTracker/trumptracker.github.io/blob/master/CONTRIBUTING.md) pages.
- [x] [Searched](https://github.com/TrumpTracker/trumptracker.github.io/pulls?utf8=%E2%9C%93&q=) through previous Pull Requests for similar issues including closed ones or just looking at the promises template

---